### PR TITLE
support for online demo update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.kyligence</groupId>
     <artifactId>notebook-console</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/CellInfoDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/CellInfoDTO.java
@@ -1,6 +1,7 @@
 package io.kyligence.notebook.console.bean.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kyligence.notebook.console.bean.entity.CellCommit;
 import io.kyligence.notebook.console.bean.entity.CellInfo;
 import io.kyligence.notebook.console.util.EntityUtils;
 import lombok.Data;
@@ -28,6 +29,18 @@ public class CellInfoDTO {
         cellInfoDTO.setId(EntityUtils.toStr(cellInfo.getId()));
         cellInfoDTO.setContent(cellInfo.getContent());
         cellInfoDTO.setJobId((cellInfo.getLastJobId()));
+        return cellInfoDTO;
+    }
+
+    public static CellInfoDTO valueOf(CellCommit committedCellInfo){
+        if (committedCellInfo == null) {
+            return null;
+        }
+
+        CellInfoDTO cellInfoDTO = new CellInfoDTO();
+        cellInfoDTO.setId(EntityUtils.toStr(committedCellInfo.getCellId()));
+        cellInfoDTO.setContent(committedCellInfo.getContent());
+        cellInfoDTO.setJobId((committedCellInfo.getLastJobId()));
         return cellInfoDTO;
     }
 }

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/DemoInfoDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/DemoInfoDTO.java
@@ -1,0 +1,36 @@
+package io.kyligence.notebook.console.bean.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kyligence.notebook.console.util.EntityUtils;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class DemoInfoDTO {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("commit_id")
+    private String commitId;
+
+    @JsonProperty("is_demo")
+    private Boolean isDemo;
+
+    public static DemoInfoDTO valueOf(Integer id, String name, String type, String commitId) {
+        DemoInfoDTO result = new DemoInfoDTO();
+        result.setId(EntityUtils.toStr(id));
+        result.setName(name);
+        result.setType(type);
+        result.setIsDemo(true);
+        result.setCommitId(commitId);
+        return result;
+    }
+}

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/NotebookDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/NotebookDTO.java
@@ -1,7 +1,9 @@
 package io.kyligence.notebook.console.bean.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.kyligence.notebook.console.bean.entity.CellCommit;
 import io.kyligence.notebook.console.bean.entity.CellInfo;
+import io.kyligence.notebook.console.bean.entity.NotebookCommit;
 import io.kyligence.notebook.console.bean.entity.NotebookInfo;
 import io.kyligence.notebook.console.util.EntityUtils;
 import lombok.Data;
@@ -28,6 +30,8 @@ public class NotebookDTO extends ExecFileDTO{
     @JsonProperty("cell_list")
     private List<CellInfoDTO> cellList;
 
+    @JsonProperty("is_demo")
+    private Boolean isDemo;
 
     public static NotebookDTO valueOf(NotebookInfo notebookInfo, List<Integer> cellIds, List<CellInfo> cellInfos) {
         if (notebookInfo == null) {
@@ -56,4 +60,26 @@ public class NotebookDTO extends ExecFileDTO{
         return valueOf(notebookInfo, null, null);
     }
 
+    public static NotebookDTO valueOf(NotebookInfo notebookInfo, List<Integer> cellIds, NotebookCommit notebookCommit, List<CellCommit> cellInfos) {
+        if (notebookInfo == null) {
+            return null;
+        }
+
+        NotebookDTO notebookDTO = new NotebookDTO();
+        notebookDTO.setId(EntityUtils.toStr(notebookInfo.getId()));
+        notebookDTO.setName(notebookCommit.getName());
+        notebookDTO.setUser(notebookInfo.getUser());
+
+        if (cellIds != null && !cellIds.isEmpty() && cellInfos != null) {
+            Map<Integer, CellCommit> cellInfoMap = new HashMap<>();
+            cellInfos.forEach(committedCellInfo -> cellInfoMap.put(committedCellInfo.getCellId(), committedCellInfo));
+
+            List<CellInfoDTO> cellInfoDTOS = cellIds.stream().map(cellId -> {
+                CellCommit committedCellInfo = cellInfoMap.get(cellId);
+                return CellInfoDTO.valueOf(committedCellInfo);
+            }).collect(Collectors.toList());
+            notebookDTO.setCellList(cellInfoDTOS);
+        }
+        return notebookDTO;
+    }
 }

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/NotebookTreeDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/NotebookTreeDTO.java
@@ -2,7 +2,9 @@ package io.kyligence.notebook.console.bean.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kyligence.notebook.console.bean.entity.ExecFileInfo;
+import io.kyligence.notebook.console.bean.entity.NotebookCommit;
 import io.kyligence.notebook.console.bean.entity.NotebookFolder;
+import io.kyligence.notebook.console.bean.entity.WorkflowCommit;
 import io.kyligence.notebook.console.util.EntityUtils;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -26,8 +28,47 @@ public class NotebookTreeDTO {
     @JsonProperty("type")
     public String type;
 
+    @JsonProperty("commit_id")
+    public String commitId;
+
+    @JsonProperty("is_demo")
+    public Boolean isDemo;
+
     @JsonProperty("list")
     public List<NotebookTreeDTO> list;
+
+
+    public static NotebookTreeDTO valueOfDemoFiles(List<NotebookCommit> notebookDemos, List<WorkflowCommit> workflowDemos){
+        NotebookTreeDTO demoFolder = new NotebookTreeDTO();
+        demoFolder.setFolderId("0");
+        demoFolder.setName("OnlineDemos");
+        demoFolder.setIsDemo(true);
+        List<NotebookTreeDTO> demoList = notebookDemos.stream().map(
+                demoNb -> {
+                    NotebookTreeDTO entity = new NotebookTreeDTO();
+                    entity.setId(demoNb.getNotebookId().toString());
+                    entity.setCommitId(demoNb.getCommitId());
+                    entity.setIsDemo(true);
+                    entity.setName(demoNb.getName());
+                    entity.setType("notebook");
+                    return entity;
+                }
+        ).collect(Collectors.toList());
+
+        demoList.addAll(workflowDemos.stream().map(
+                demoWf -> {
+                    NotebookTreeDTO entity = new NotebookTreeDTO();
+                    entity.setId(demoWf.getWorkflowId().toString());
+                    entity.setCommitId(demoWf.getCommitId());
+                    entity.setIsDemo(true);
+                    entity.setName(demoWf.getName());
+                    entity.setType("workflow");
+                    return entity;
+                }
+        ).collect(Collectors.toList()));
+        demoFolder.setList(demoList);
+        return demoFolder;
+    }
 
     public static NotebookTreeDTO valueOf(List<ExecFileInfo> execFiles, List<NotebookFolder> folders) {
         NotebookTreeDTO notebookTree = buildFolderTree(folders);
@@ -178,6 +219,5 @@ public class NotebookTreeDTO {
         });
         return tree;
     }
-
 
 }

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/OpenedExecFileDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/OpenedExecFileDTO.java
@@ -14,6 +14,15 @@ public class OpenedExecFileDTO {
     @JsonProperty("name")
     private String name;
 
+    @JsonProperty("is_demo")
+    private Boolean isDemo;
+
+    @JsonProperty("uniq")
+    private String uniq;
+
+    @JsonProperty("commit_id")
+    private String commitId;
+
     @JsonProperty("active")
     private String active;
 

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/UserInfoDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/UserInfoDTO.java
@@ -1,5 +1,6 @@
 package io.kyligence.notebook.console.bean.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kyligence.notebook.console.bean.entity.UserInfo;
 import io.kyligence.notebook.console.util.EntityUtils;
 import lombok.Data;
@@ -13,10 +14,14 @@ public class UserInfoDTO {
 
     private String username;
 
+    @JsonProperty("is_admin")
+    private Boolean isAdmin;
+
     public static UserInfoDTO valueOf(UserInfo userInfo) {
         UserInfoDTO userInfoDTO = new UserInfoDTO();
         userInfoDTO.setId(EntityUtils.toStr(userInfo.getId()));
         userInfoDTO.setUsername(userInfo.getName());
+        userInfoDTO.setIsAdmin(userInfo.getName().equalsIgnoreCase("admin"));
         return userInfoDTO;
     }
 }

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/WorkflowDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/WorkflowDTO.java
@@ -29,6 +29,8 @@ public class WorkflowDTO extends ExecFileDTO{
     @JsonProperty("node_list")
     private List<NodeInfoDTO> nodeList;
 
+    @JsonProperty("is_demo")
+    private Boolean isDemo;
 
     public static WorkflowDTO valueOf(WorkflowInfo workflow, List<NodeInfo> nodeInfos,
                                       Map<Integer, ConnectionInfo> connectionMap) {

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/req/CloneExecFileReq.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/req/CloneExecFileReq.java
@@ -22,4 +22,7 @@ public class CloneExecFileReq {
     @NotBlank
     @JsonProperty("type")
     private String type;
+
+    @JsonProperty("commit_id")
+    private String commitId;
 }

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/req/EntityInfoReq.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/req/EntityInfoReq.java
@@ -1,0 +1,20 @@
+package io.kyligence.notebook.console.bean.dto.req;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EntityInfoReq {
+    @JsonProperty("entity_type")
+    private String entityType;
+
+    @JsonProperty("entity_id")
+    private Integer entityId;
+
+    @JsonProperty("entity_name")
+    private String entityName;
+
+}
+

--- a/src/main/java/io/kyligence/notebook/console/bean/entity/CellCommit.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/entity/CellCommit.java
@@ -1,0 +1,34 @@
+package io.kyligence.notebook.console.bean.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "cell_commit")
+@Data
+public class CellCommit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "cell_id")
+    private Integer cellId;
+
+    @Column(name = "notebook_id")
+    private Integer notebookId;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "commit_id")
+    private String commitId;
+
+    @Column(name = "last_job_id")
+    private String lastJobId;
+
+    @Column(name = "create_time")
+    private Timestamp createTime;
+}

--- a/src/main/java/io/kyligence/notebook/console/bean/entity/NodeCommit.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/entity/NodeCommit.java
@@ -1,0 +1,46 @@
+package io.kyligence.notebook.console.bean.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "node_commit")
+@Data
+public class NodeCommit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "workflow_id", nullable = false)
+    private Integer workflowId;
+
+    @Column(name = "node_id", nullable = false)
+    private Integer nodeId;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "user", nullable = false)
+    private String user;
+
+    @Column(name = "type")
+    private String type;
+
+    @Column(name = "position")
+    private String position;
+
+    @Column(name = "input")
+    private String input;
+
+    @Column(name = "output")
+    private String output;
+
+    @Column(name = "commit_id")
+    private String commitId;
+
+    @Column(name = "create_time")
+    private Timestamp createTime;
+}

--- a/src/main/java/io/kyligence/notebook/console/bean/entity/NotebookCommit.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/entity/NotebookCommit.java
@@ -1,0 +1,30 @@
+package io.kyligence.notebook.console.bean.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Data
+@Entity
+@Table(name = "notebook_commit")
+public class NotebookCommit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "notebook_id", nullable = false)
+    private Integer notebookId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "cell_list", nullable = false)
+    private String cellList;
+
+    @Column(name = "commit_id")
+    private String commitId;
+
+    @Column(name = "create_time", nullable = false)
+    private Timestamp createTime;
+}

--- a/src/main/java/io/kyligence/notebook/console/bean/entity/SharedFileInfo.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/entity/SharedFileInfo.java
@@ -1,0 +1,34 @@
+package io.kyligence.notebook.console.bean.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "shared_file")
+@Data
+public class SharedFileInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "entity_id", nullable = false)
+    private Integer entityId;
+
+    @Column(name = "entity_type", nullable = false)
+    private String entityType;
+
+    @Column(name = "owner", nullable = false)
+    private String owner;
+
+    @Column(name = "commit_id")
+    private String commitId;
+
+    @Column(name = "create_time")
+    private Timestamp createTime;
+
+    @Column(name = "update_time")
+    private Timestamp updateTime;
+}

--- a/src/main/java/io/kyligence/notebook/console/bean/entity/WorkflowCommit.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/entity/WorkflowCommit.java
@@ -1,0 +1,27 @@
+package io.kyligence.notebook.console.bean.entity;
+
+import lombok.Data;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Data
+@Entity
+@Table(name = "workflow_commit")
+public class WorkflowCommit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(name = "workflow_id", nullable = false)
+    private Integer workflowId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "commit_id")
+    private String commitId;
+
+    @Column(name = "create_time", nullable = false)
+    private Timestamp createTime;
+}

--- a/src/main/java/io/kyligence/notebook/console/controller/NotebookController.java
+++ b/src/main/java/io/kyligence/notebook/console/controller/NotebookController.java
@@ -5,6 +5,7 @@ import io.kyligence.notebook.console.bean.dto.req.CodeSuggestionReq;
 import io.kyligence.notebook.console.bean.dto.req.CreateCellReq;
 import io.kyligence.notebook.console.bean.dto.req.SaveNotebookReq;
 import io.kyligence.notebook.console.bean.entity.CellInfo;
+import io.kyligence.notebook.console.bean.entity.NotebookCommit;
 import io.kyligence.notebook.console.bean.entity.NotebookInfo;
 import io.kyligence.notebook.console.exception.ByzerException;
 import io.kyligence.notebook.console.exception.ErrorCodeEnum;
@@ -99,9 +100,10 @@ public class NotebookController {
     @ApiOperation("Get Notebook Content")
     @GetMapping("/notebook/{id}")
     @Permission
-    public Response<NotebookDTO> get(@PathVariable("id") @NotNull Integer id) {
+    public Response<NotebookDTO> get(@PathVariable("id") @NotNull Integer id,
+                                     @RequestParam(value = "commit_id", required = false) String commitId) {
         String user = WebUtils.getCurrentLoginUser();
-        NotebookDTO notebookDTO = notebookService.getNotebook(id, user);
+        NotebookDTO notebookDTO = notebookService.getNotebook(id, user, commitId);
         return new Response<NotebookDTO>().data(notebookDTO);
     }
 
@@ -166,7 +168,7 @@ public class NotebookController {
     public Response<IdNameDTO> delCell(@PathVariable("notebookId") @NotNull Integer notebookId) {
         String user = WebUtils.getCurrentLoginUser();
         NotebookInfo notebookInfo = notebookService.findById(notebookId);
-        notebookService.checkExecFileAvailable(user, notebookInfo);
+        notebookService.checkExecFileAvailable(user, notebookInfo, null);
 
         List<CellInfo> cells = notebookService.getCellInfos(notebookId);
         if (cells != null) {
@@ -218,16 +220,20 @@ public class NotebookController {
     @ApiOperation("Get User Default Notebook")
     @GetMapping("/notebook/default")
     @Permission
-    public Response<IdNameTypeDTO> getDefaultNotebook() {
-        String user = WebUtils.getCurrentLoginUser();
-        NotebookInfo notebookInfo = notebookService.getDefault(user);
+    public Response<DemoInfoDTO> getDefaultNotebook() {
+        NotebookCommit notebookCommit = notebookService.getDefaultDemo();
 
-        if (notebookInfo == null) {
+        if (notebookCommit == null) {
             return new Response<>();
         }
 
-        return new Response<IdNameTypeDTO>().data(
-                IdNameTypeDTO.valueOf(notebookInfo.getId(), notebookInfo.getName(), "notebook"));
+        return new Response<DemoInfoDTO>().data(
+                DemoInfoDTO.valueOf(
+                        notebookCommit.getNotebookId(),
+                        notebookCommit.getName(),
+                        "notebook",
+                        notebookCommit.getCommitId()
+                ));
     }
 
     @ApiOperation("Create Sample Notebook")
@@ -250,5 +256,14 @@ public class NotebookController {
     public Response<List<CodeSuggestDTO>> getCodeSuggestion(@RequestBody CodeSuggestionReq suggestionReq) {
         List<CodeSuggestDTO> suggestionDTOS = notebookService.getCodeSuggestion(suggestionReq);
         return new Response<List<CodeSuggestDTO>>().data(suggestionDTOS);
+    }
+
+    @ApiOperation("Commit Notebook")
+    @PostMapping("/notebook/{id}/commit")
+    @Permission
+    public Response<String> commit(@PathVariable("id") @NotNull Integer notebookId){
+        String user = WebUtils.getCurrentLoginUser();
+        NotebookCommit commit = notebookService.commit(user, notebookId);
+        return new Response<String>().data(commit.getCommitId());
     }
 }

--- a/src/main/java/io/kyligence/notebook/console/controller/NotebookHelper.java
+++ b/src/main/java/io/kyligence/notebook/console/controller/NotebookHelper.java
@@ -38,12 +38,12 @@ public class NotebookHelper {
     private UploadFileService uploadFileService;
 
     @Transactional
-    protected NotebookInfo importNotebook(NotebookDTO notebookDTO, Integer folderId, String type) {
+    protected NotebookInfo importNotebook(NotebookDTO notebookDTO, Integer folderId, String type, String user) {
         // create notebook
-        String user = WebUtils.getCurrentLoginUser();
+
         long timestamp = System.currentTimeMillis();
         NotebookInfo notebookInfo = new NotebookInfo();
-        notebookInfo.setUser(WebUtils.getCurrentLoginUser());
+        notebookInfo.setUser(user);
 
         if (notebookService.isNotebookExist(user, notebookDTO.getName(), folderId)) {
             String time = new SimpleDateFormat("yyyyMMddHHmmss", Locale.getDefault(Locale.Category.FORMAT)).format(new Date());
@@ -82,6 +82,12 @@ public class NotebookHelper {
         return notebookService.save(notebookInfo);
     }
 
+    protected NotebookInfo importNotebook(NotebookDTO notebookDTO, Integer folderId, String type) {
+        // create notebook
+        String user = WebUtils.getCurrentLoginUser();
+        return importNotebook(notebookDTO, folderId, type, user);
+    }
+
     protected NotebookInfo importNotebook(NotebookDTO notebookDTO) {
         return importNotebook(notebookDTO, null, null);
     }
@@ -91,7 +97,7 @@ public class NotebookHelper {
     }
 
     @SneakyThrows
-    protected NotebookInfo createSampleDemo(String user) {
+    public NotebookInfo createSampleDemo(String user) {
         log.info("Creating Demo For User:" + user);
         String username = user.toLowerCase();
         NotebookInfo result = null;
@@ -104,11 +110,11 @@ public class NotebookHelper {
                 log.info("Import File: " + demo.getName());
                 if (demo.getName().endsWith(".mlnb") || demo.getName().endsWith(".bznb")) {
                     NotebookDTO notebookDTO = JacksonUtils.readJson(in, NotebookDTO.class);
-                    NotebookInfo nb= importNotebook(notebookDTO, null, "default");
+                    NotebookInfo nb= importNotebook(notebookDTO, null, "default", username);
                     if (result == null) result = nb;
                 } else if (demo.getName().endsWith(".mlwf") || demo.getName().endsWith(".bzwf")){
                     WorkflowDTO workflowDTO = JacksonUtils.readJson(in, WorkflowDTO.class);
-                    workflowService.importWorkflow(workflowDTO, null, "default");
+                    workflowService.importWorkflow(workflowDTO, null, "default", username);
                 }
 
             } catch (Exception e) {

--- a/src/main/java/io/kyligence/notebook/console/controller/SettingsController.java
+++ b/src/main/java/io/kyligence/notebook/console/controller/SettingsController.java
@@ -4,12 +4,14 @@ package io.kyligence.notebook.console.controller;
 import io.kyligence.notebook.console.NotebookConfig;
 import io.kyligence.notebook.console.bean.dto.*;
 import io.kyligence.notebook.console.bean.dto.req.CUConnectionReq;
+import io.kyligence.notebook.console.bean.dto.req.EntityInfoReq;
 import io.kyligence.notebook.console.bean.dto.req.SettingsUpdateReq;
 import io.kyligence.notebook.console.bean.entity.ConnectionInfo;
 import io.kyligence.notebook.console.bean.entity.NodeDefInfo;
 import io.kyligence.notebook.console.bean.entity.ParamDefInfo;
 import io.kyligence.notebook.console.bean.entity.SystemConfig;
 import io.kyligence.notebook.console.service.ConnectionService;
+import io.kyligence.notebook.console.service.FileShareService;
 import io.kyligence.notebook.console.service.NodeDefService;
 import io.kyligence.notebook.console.service.SystemService;
 import io.kyligence.notebook.console.support.DisableInTrial;
@@ -42,6 +44,9 @@ public class SettingsController {
 
     @Autowired
     private NodeDefService nodeDefService;
+
+    @Autowired
+    private FileShareService fileShareService;
 
     private static final NotebookConfig config = NotebookConfig.getInstance();
 
@@ -216,4 +221,23 @@ public class SettingsController {
         List<ParamDefInfo> allNodeParams = nodeDefService.getParamDefByNodeDefId(nodeDefInfo.getId());
         return new Response<ParamDefDTO>().data(ParamDefDTO.valueOf(paramDefInfo, allNodeParams));
     }
+
+    @ApiOperation("Set/Update Demo")
+    @PostMapping("/settings/demo")
+    @Permission
+    public Response<String> addDemo(@RequestBody @Validated EntityInfoReq entityInfo) {
+        String user = WebUtils.getCurrentLoginUser();
+        fileShareService.addDemo(user, entityInfo.getEntityId(), entityInfo.getEntityType());
+        return new Response<String>().data("success");
+    }
+
+    @ApiOperation("Delete Demo")
+    @PostMapping("/settings/demo/remove")
+    @Permission
+    public Response<String> deleteDemo(@RequestBody @Validated EntityInfoReq entityInfo) {
+        String user = WebUtils.getCurrentLoginUser();
+        fileShareService.deleteDemo(user, entityInfo.getEntityId(), entityInfo.getEntityType());
+        return new Response<String>().data("success");
+    }
+
 }

--- a/src/main/java/io/kyligence/notebook/console/controller/UserController.java
+++ b/src/main/java/io/kyligence/notebook/console/controller/UserController.java
@@ -104,7 +104,8 @@ public class UserController {
 
     @Async
     protected void postSignup(String user) {
-        notebookHelper.createSampleDemo(user);
+        log.info("skip create sample for: " + user);
+        // notebookHelper.createSampleDemo(user);
     }
 
 

--- a/src/main/java/io/kyligence/notebook/console/controller/WorkflowController.java
+++ b/src/main/java/io/kyligence/notebook/console/controller/WorkflowController.java
@@ -74,15 +74,10 @@ public class WorkflowController {
     @ApiOperation("Get Workflow Content")
     @GetMapping("/workflow/{id}")
     @Permission
-    public Response<WorkflowDTO> getWorkflow(@PathVariable("id") @NotNull Integer id) {
+    public Response<WorkflowDTO> getWorkflow(@PathVariable("id") @NotNull Integer id,
+                                             @RequestParam(value = "commit_id", required = false) String commitId) {
         String user = WebUtils.getCurrentLoginUser();
-        WorkflowInfo workflowInfo = workflowService.findById(id);
-        if (workflowInfo == null) {
-            return new Response<WorkflowDTO>().data(null);
-        }
-        List<NodeInfo> nodeInfoList = workflowService.findNodeByWorkflow(id);
-        Map<Integer, ConnectionInfo> connectionInfoMap = workflowService.getUserConnectionMap(user);
-        return new Response<WorkflowDTO>().data(WorkflowDTO.valueOf(workflowInfo, nodeInfoList, connectionInfoMap));
+        return new Response<WorkflowDTO>().data(workflowService.getWorkflow(id, user, commitId));
     }
 
     @ApiOperation("Delete Node")
@@ -98,9 +93,10 @@ public class WorkflowController {
     @ApiOperation("Get Workflow Script Content")
     @GetMapping("/workflow/{id}/script")
     @Permission
-    public Response<WorkflowContentDTO> getWorkflowContent(@PathVariable("id") @NotNull Integer id) {
+    public Response<WorkflowContentDTO> getWorkflowContent(@PathVariable("id") @NotNull Integer id,
+                                                           @RequestParam(value = "commit_id", required = false) String commitId) {
         String user = WebUtils.getCurrentLoginUser();
-        WorkflowContentDTO content = workflowService.getWorkflowContent(user, id);
+        WorkflowContentDTO content = workflowService.getWorkflowContent(user, id, commitId);
         return new Response<WorkflowContentDTO>().data(content);
     }
 
@@ -200,7 +196,7 @@ public class WorkflowController {
     public Response<IdDTO> deleteWorkflow(@PathVariable("workflowId") @NotNull Integer workflowId) {
         String user = WebUtils.getCurrentLoginUser();
         WorkflowInfo workflowInfo = workflowService.findById(workflowId);
-        workflowService.checkExecFileAvailable(user, workflowInfo);
+        workflowService.checkExecFileAvailable(user, workflowInfo, null);
         workflowService.delete(workflowId);
         return new Response<IdDTO>().data(IdDTO.valueOf(workflowId));
     }

--- a/src/main/java/io/kyligence/notebook/console/dao/CellCommitRepository.java
+++ b/src/main/java/io/kyligence/notebook/console/dao/CellCommitRepository.java
@@ -1,0 +1,20 @@
+package io.kyligence.notebook.console.dao;
+
+import io.kyligence.notebook.console.bean.entity.CellCommit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface CellCommitRepository extends JpaRepository<CellCommit, Integer> {
+
+    @Query(value = "select * from cell_commit where notebook_id = ?1 and commit_id = ?2", nativeQuery = true)
+    List<CellCommit> findByCommit(Integer notebookId, String commitId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "delete from cell_commit where notebook_id = ?1", nativeQuery = true)
+    void deleteByNotebook(Integer notebookId);
+}

--- a/src/main/java/io/kyligence/notebook/console/dao/NodeCommitRepository.java
+++ b/src/main/java/io/kyligence/notebook/console/dao/NodeCommitRepository.java
@@ -1,0 +1,21 @@
+package io.kyligence.notebook.console.dao;
+
+import io.kyligence.notebook.console.bean.entity.NodeCommit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface NodeCommitRepository extends JpaRepository<NodeCommit, Integer> {
+
+    @Query(value = "select * from node_commit where workflow_id = ?1 and commit_id = ?2", nativeQuery = true)
+    List<NodeCommit> findByCommit(Integer workflowId, String commit_id);
+
+    @Modifying
+    @Transactional
+    @Query(value = "delete from node_commit where workflow_id = ?1", nativeQuery = true)
+    void deleteByWorkflow(Integer workflowId);
+
+}

--- a/src/main/java/io/kyligence/notebook/console/dao/NotebookCommitRepository.java
+++ b/src/main/java/io/kyligence/notebook/console/dao/NotebookCommitRepository.java
@@ -1,0 +1,24 @@
+package io.kyligence.notebook.console.dao;
+
+import io.kyligence.notebook.console.bean.entity.NotebookCommit;
+import io.kyligence.notebook.console.bean.entity.SharedFileInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface NotebookCommitRepository extends JpaRepository<NotebookCommit, Integer> {
+
+    @Query(value = "select * from notebook_commit where notebook_id = ?1", nativeQuery = true)
+    List<NotebookCommit> listCommit(Integer notebook_id);
+
+    @Query(value = "select * from notebook_commit where notebook_id = ?1 and commit_id = ?2", nativeQuery = true)
+    List<NotebookCommit> findByCommit(Integer notebook_id, String commitId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "delete from notebook_commit where notebook_id = ?1", nativeQuery = true)
+    void deleteByNotebook(Integer notebookId);
+}

--- a/src/main/java/io/kyligence/notebook/console/dao/SharedFileRepository.java
+++ b/src/main/java/io/kyligence/notebook/console/dao/SharedFileRepository.java
@@ -1,0 +1,34 @@
+package io.kyligence.notebook.console.dao;
+
+import io.kyligence.notebook.console.bean.entity.SharedFileInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface SharedFileRepository extends JpaRepository<SharedFileInfo, Integer> {
+    @Query(value = "select * from shared_file where owner = ?1 order by id", nativeQuery = true)
+    List<SharedFileInfo> findByOwner(String owner);
+
+    @Query(value = "select * from shared_file where entity_id = ?1 and entity_type = ?2", nativeQuery = true)
+    List<SharedFileInfo> findByEntity(Integer entityId, String entityType);
+
+    @Query(value = "select * from shared_file where entity_id = ?2 and entity_type = ?3 and owner = ?1", nativeQuery = true)
+    List<SharedFileInfo> findByEntity(String owner, Integer entityId, String entityType);
+
+    @Query(value = "select * from shared_file where entity_id = ?2 and entity_type = ?3 and owner = ?1 and commit_id = ?4", nativeQuery = true)
+    List<SharedFileInfo> findByCommit(String owner, Integer entityId, String entityType, String commitId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "delete from shared_file where entity_id = ?2 and entity_type = ?3 and owner = ?1", nativeQuery = true)
+    void deleteByEntity(String owner, Integer entityId, String entityType);
+
+    @Modifying
+    @Transactional
+    @Query(value = "update shared_file set commit_id = ?4 where entity_id = ?2 and entity_type = ?3 and owner = ?1", nativeQuery = true)
+    void updateCommit(String owner, Integer entityId, String entityType, String commitId);
+
+}

--- a/src/main/java/io/kyligence/notebook/console/dao/WorkflowCommitRepository.java
+++ b/src/main/java/io/kyligence/notebook/console/dao/WorkflowCommitRepository.java
@@ -1,0 +1,23 @@
+package io.kyligence.notebook.console.dao;
+
+import io.kyligence.notebook.console.bean.entity.WorkflowCommit;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+public interface WorkflowCommitRepository extends JpaRepository<WorkflowCommit, Integer> {
+
+    @Query(value = "select * from workflow_commit where workflow_id = ?1", nativeQuery = true)
+    List<WorkflowCommit> listCommit(Integer workflowId);
+
+    @Query(value = "select * from workflow_commit where workflow_id = ?1 and commit_id = ?2", nativeQuery = true)
+    List<WorkflowCommit> findByCommit(Integer workflowId, String commitId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "delete from workflow_commit where workflow_id = ?1", nativeQuery = true)
+    void deleteByWorkflow(Integer workflowId);
+}

--- a/src/main/java/io/kyligence/notebook/console/service/FileInterface.java
+++ b/src/main/java/io/kyligence/notebook/console/service/FileInterface.java
@@ -17,7 +17,7 @@ public interface FileInterface {
 
     ExecFileInfo findById(Integer id);
 
-    void checkExecFileAvailable(String user, ExecFileInfo execFileInfo);
+    void checkExecFileAvailable(String user, ExecFileInfo execFileInfo, String commitId);
 
     ExecFileInfo find(String user, String name, Integer id);
 

--- a/src/main/java/io/kyligence/notebook/console/service/FileShareService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/FileShareService.java
@@ -46,9 +46,7 @@ public class FileShareService {
             notebookService.find(ADMIN_ACCOUNT).stream()
                     .filter(nb -> nb.getType().equalsIgnoreCase("default"))
                     .forEach(nb -> addNotebookDemo(ADMIN_ACCOUNT, nb.getId()));
-            workflowService.find(ADMIN_ACCOUNT).stream()
-                    .filter(wf -> wf.getType().equalsIgnoreCase("default"))
-                    .forEach(wf -> addWorkflowDemo(ADMIN_ACCOUNT, wf.getId()));
+            workflowService.find(ADMIN_ACCOUNT).forEach(wf -> addWorkflowDemo(ADMIN_ACCOUNT, wf.getId()));
         }
     }
 

--- a/src/main/java/io/kyligence/notebook/console/service/FileShareService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/FileShareService.java
@@ -1,0 +1,152 @@
+package io.kyligence.notebook.console.service;
+
+import io.kyligence.notebook.console.bean.dto.NotebookTreeDTO;
+import io.kyligence.notebook.console.bean.entity.*;
+import io.kyligence.notebook.console.controller.NotebookHelper;
+import io.kyligence.notebook.console.dao.SharedFileRepository;
+import io.kyligence.notebook.console.exception.ByzerException;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.compress.utils.Lists;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@Slf4j
+public class FileShareService {
+    @Autowired
+    private SharedFileRepository sharedFileRepository;
+
+    @Autowired
+    private NotebookService notebookService;
+
+    @Autowired
+    private NotebookHelper notebookHelper;
+
+    @Autowired
+    private WorkflowService workflowService;
+
+    private NotebookTreeDTO cachedDemo;
+
+    private final String ADMIN_ACCOUNT = "admin";
+
+    @PostConstruct
+    public void createDefaultDemo(){
+        // create default sample for admin
+        if (Objects.isNull(notebookService.getDefault(ADMIN_ACCOUNT))) {
+            notebookHelper.createSampleDemo(ADMIN_ACCOUNT);
+        }
+
+        // create default demo for all user from admin default sample
+        if (Objects.isNull(notebookService.getDefaultDemo())){
+            notebookService.find(ADMIN_ACCOUNT).stream()
+                    .filter(nb -> nb.getType().equalsIgnoreCase("default"))
+                    .forEach(nb -> addNotebookDemo(ADMIN_ACCOUNT, nb.getId()));
+            workflowService.find(ADMIN_ACCOUNT).stream()
+                    .filter(wf -> wf.getType().equalsIgnoreCase("default"))
+                    .forEach(wf -> addWorkflowDemo(ADMIN_ACCOUNT, wf.getId()));
+        }
+    }
+
+    public void addDemo(String user, Integer entityId, String entityType) {
+        if (!user.equalsIgnoreCase(ADMIN_ACCOUNT)) {
+            throw new ByzerException("Not Authorized");
+        }
+        if (entityType.equalsIgnoreCase("notebook")) {
+            addNotebookDemo(user, entityId);
+        } else if (entityType.equalsIgnoreCase("workflow")) {
+            addWorkflowDemo(user, entityId);
+        } else {
+            throw new ByzerException("Unsupported Entity Type: [" + entityType + "]");
+        }
+        // clear cache, reload in next transaction
+        clearCachedDemo();
+    }
+
+    public void deleteDemo(String user, Integer entityId, String entityType) {
+        if (!user.equalsIgnoreCase(ADMIN_ACCOUNT)) {
+            throw new ByzerException("Not Authorized");
+        }
+        sharedFileRepository.deleteByEntity(user, entityId, entityType);
+        loadDemo();
+    }
+
+    private SharedFileInfo findByEntity(String user, Integer entityId, String entityType){
+        List<SharedFileInfo> infos = sharedFileRepository.findByEntity(user, entityId, entityType);
+        return infos.isEmpty() ? null : infos.get(0);
+    }
+
+    private void addWorkflowDemo(String user, Integer workflowId) {
+        WorkflowCommit commit = workflowService.commit(user, workflowId);
+        SharedFileInfo sharedFileInfo = findByEntity(user, workflowId, "workflow");
+        long timestamp = System.currentTimeMillis();
+
+        if (Objects.isNull(sharedFileInfo)) {
+            sharedFileInfo = new SharedFileInfo();
+            sharedFileInfo.setEntityId(workflowId);
+            sharedFileInfo.setEntityType("workflow");
+            sharedFileInfo.setCommitId(commit.getCommitId());
+            sharedFileInfo.setOwner(user);
+            sharedFileInfo.setCreateTime(new Timestamp(timestamp));
+            sharedFileInfo.setUpdateTime(new Timestamp(timestamp));
+            sharedFileRepository.save(sharedFileInfo);
+        } else {
+            sharedFileRepository.updateCommit(user, workflowId, "workflow", commit.getCommitId());
+        }
+    }
+
+    private void addNotebookDemo(String user, Integer notebookId) {
+        NotebookCommit commit = notebookService.commit(user, notebookId);
+        SharedFileInfo sharedFileInfo = findByEntity(user, notebookId, "notebook");
+        long timestamp = System.currentTimeMillis();
+
+        if (Objects.isNull(sharedFileInfo)) {
+            sharedFileInfo = new SharedFileInfo();
+            sharedFileInfo.setEntityId(notebookId);
+            sharedFileInfo.setEntityType("notebook");
+            sharedFileInfo.setCommitId(commit.getCommitId());
+            sharedFileInfo.setOwner(user);
+            sharedFileInfo.setCreateTime(new Timestamp(timestamp));
+            sharedFileInfo.setUpdateTime(new Timestamp(timestamp));
+            sharedFileRepository.save(sharedFileInfo);
+        } else {
+            sharedFileRepository.updateCommit(user, notebookId, "notebook", commit.getCommitId());
+        }
+    }
+
+    public NotebookTreeDTO getDemo() {
+        if (Objects.isNull(this.cachedDemo)) {
+            this.loadDemo();
+        }
+        return this.cachedDemo;
+    }
+
+    private void loadDemo() {
+        List<SharedFileInfo> demos = sharedFileRepository.findByOwner(ADMIN_ACCOUNT);
+        List<NotebookCommit> demoNotebooks = Lists.newArrayList();
+        List<WorkflowCommit> demoWorkflows = Lists.newArrayList();
+        demos.forEach(
+                demo -> {
+                    if (demo.getEntityType().equalsIgnoreCase("notebook")) {
+                        NotebookCommit nb = notebookService.findCommit(demo.getEntityId(), demo.getCommitId());
+                        if (Objects.nonNull(nb)) demoNotebooks.add(nb);
+                    } else if (demo.getEntityType().equalsIgnoreCase("workflow")) {
+                        WorkflowCommit wf = workflowService.findCommit(demo.getEntityId(), demo.getCommitId());
+                        if (Objects.nonNull(wf)) demoWorkflows.add(wf);
+                    }
+                }
+        );
+        this.cachedDemo = NotebookTreeDTO.valueOfDemoFiles(demoNotebooks, demoWorkflows);
+    }
+
+    /**
+     * Clear Demo Cache.
+     */
+    private void clearCachedDemo(){
+        this.cachedDemo = null;
+    }
+}

--- a/src/main/java/io/kyligence/notebook/console/service/FolderService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/FolderService.java
@@ -27,6 +27,9 @@ public class FolderService {
     @Autowired
     private WorkflowService workflowService;
 
+    @Autowired
+    private FileShareService fileShareService;
+
     @Transactional
     public NotebookFolder createFolder(String user, String folderPath) {
         if (isFolderExist(user, folderPath)) {
@@ -91,7 +94,9 @@ public class FolderService {
         List<ExecFileInfo> execFiles = ExecFileInfo.createArrayFiles(notebooks, workflows);
 
         // if trans here, can not figure out type: notebook/workflow
-        return NotebookTreeDTO.valueOf(execFiles, folders);
+        NotebookTreeDTO userFiles = NotebookTreeDTO.valueOf(execFiles, folders);
+        userFiles.getList().add(0, fileShareService.getDemo());
+        return userFiles;
     }
 
 }

--- a/src/main/java/io/kyligence/notebook/console/service/SchedulerService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/SchedulerService.java
@@ -158,9 +158,9 @@ public class SchedulerService {
     private String getScript(String entityType, String entityId, Map<String, String> options) {
         switch (entityType.toLowerCase()) {
             case "notebook":
-                return notebookService.getNotebookScripts("admin", Integer.valueOf(entityId), options);
+                return notebookService.getNotebookScripts("admin", Integer.valueOf(entityId), null, options);
             case "workflow":
-                return workflowService.getWorkflowScripts("admin", Integer.valueOf(entityId), options);
+                return workflowService.getWorkflowScripts("admin", Integer.valueOf(entityId), null, options);
             default:
                 return "";
         }

--- a/src/main/java/io/kyligence/notebook/console/service/WorkflowService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/WorkflowService.java
@@ -3,13 +3,11 @@ package io.kyligence.notebook.console.service;
 import io.kyligence.notebook.console.NotebookConfig;
 import io.kyligence.notebook.console.bean.dto.*;
 import io.kyligence.notebook.console.bean.entity.*;
-import io.kyligence.notebook.console.dao.ModelInfoRepository;
+import io.kyligence.notebook.console.dao.*;
 import io.kyligence.notebook.console.exception.EngineAccessException;
 import io.kyligence.notebook.console.scalalib.hint.HintManager;
 import io.kyligence.notebook.console.support.ETEnum;
 import io.kyligence.notebook.console.util.*;
-import io.kyligence.notebook.console.dao.NodeInfoRepository;
-import io.kyligence.notebook.console.dao.WorkflowRepository;
 import io.kyligence.notebook.console.exception.ByzerException;
 import io.kyligence.notebook.console.exception.ErrorCodeEnum;
 import io.kyligence.notebook.console.support.CriteriaQueryBuilder;
@@ -31,6 +29,9 @@ public class WorkflowService implements FileInterface {
     private WorkflowRepository workflowRepository;
 
     @Autowired
+    private WorkflowCommitRepository workflowCommitRepository;
+
+    @Autowired
     private NotebookService notebookService;
 
     @Autowired
@@ -40,7 +41,13 @@ public class WorkflowService implements FileInterface {
     private NodeInfoRepository nodeInfoRepository;
 
     @Autowired
+    private NodeCommitRepository nodeCommitRepository;
+
+    @Autowired
     private ModelInfoRepository modelInfoRepository;
+
+    @Autowired
+    private SharedFileRepository sharedFileRepository;
 
     @Autowired
     private ETService etService;
@@ -94,9 +101,46 @@ public class WorkflowService implements FileInterface {
     }
 
     @Transactional
+    public WorkflowCommit commit(String user, Integer workflowId) {
+        WorkflowInfo workflowInfo = findById(workflowId);
+        checkExecFileAvailable(user, workflowInfo, null);
+
+        String commitId = UUID.randomUUID().toString();
+        long timestamp = System.currentTimeMillis();
+
+        WorkflowCommit workflowCommit = new WorkflowCommit();
+
+        workflowCommit.setCommitId(commitId);
+        workflowCommit.setWorkflowId(workflowId);
+        workflowCommit.setName(workflowInfo.getName());
+        workflowCommit.setCreateTime(new Timestamp(timestamp));
+        workflowCommit = workflowCommitRepository.save(workflowCommit);
+
+        List<NodeInfo> nodes = findNodeByWorkflow(workflowId);
+
+        nodes.forEach(
+                nodeInfo -> {
+                    NodeCommit nodeCommit = new NodeCommit();
+                    nodeCommit.setCommitId(commitId);
+                    nodeCommit.setNodeId(nodeInfo.getId());
+                    nodeCommit.setContent(nodeInfo.getContent());
+                    nodeCommit.setWorkflowId(workflowId);
+                    nodeCommit.setInput(nodeInfo.getInput());
+                    nodeCommit.setOutput(nodeInfo.getOutput());
+                    nodeCommit.setUser(user);
+                    nodeCommit.setPosition(nodeInfo.getPosition());
+                    nodeCommit.setType(nodeInfo.getType());
+                    nodeCommit.setCreateTime(new Timestamp(timestamp));
+                    nodeCommitRepository.save(nodeCommit);
+                }
+        );
+        return workflowCommit;
+    }
+
+    @Transactional
     public WorkflowInfo rename(Integer workflowId, String user, String name) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
         workflowRepository.rename(workflowId, name);
         workflowInfo.setName(name);
         return workflowInfo;
@@ -107,7 +151,7 @@ public class WorkflowService implements FileInterface {
                                NodeInfoDTO.NodeContent nodeContent,
                                NodeInfoDTO.NodePosition nodePosition) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
 
         long currentTimeStamp = System.currentTimeMillis();
 
@@ -155,7 +199,7 @@ public class WorkflowService implements FileInterface {
 
     public NodeInfo updateNode(Integer workflowId, Integer nodeId, String user, String nodeType, NodeInfoDTO.NodeContent nodeContent) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
         NodeInfo nodeInfo = findNodeById(nodeId);
 
         if (nodeInfo == null) {
@@ -216,7 +260,7 @@ public class WorkflowService implements FileInterface {
     @Transactional
     public void deleteNode(Integer workflowId, Integer nodeId, String user) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
 
         nodeInfoRepository.delete(nodeId, workflowId);
         modelInfoRepository.deleteByNodeId(nodeId);
@@ -225,7 +269,7 @@ public class WorkflowService implements FileInterface {
 
     public NodeInfo updateNodePosition(Integer workflowId, Integer nodeId, String user, NodeInfoDTO.NodePosition position) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
         NodeInfo nodeInfo = findNodeById(nodeId);
 
         if (nodeInfo == null) {
@@ -237,6 +281,9 @@ public class WorkflowService implements FileInterface {
         return nodeInfo;
     }
 
+    public List<NodeCommit> getCommittedNodeInfos(Integer workflowId, String commitId) {
+        return nodeCommitRepository.findByCommit(workflowId, commitId);
+    }
 
     public List<NodeInfo> findNodeByWorkflow(Integer workflowId) {
         return nodeInfoRepository.findByWorkflow(workflowId);
@@ -252,7 +299,7 @@ public class WorkflowService implements FileInterface {
     @Transactional
     public NotebookInfo workflowToNotebook(Integer workflowId, String user, String notebookName) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
         notebookService.checkResourceLimit(user, 1);
 
         // 1. create notebook
@@ -353,10 +400,13 @@ public class WorkflowService implements FileInterface {
         return workflowInfo != null && workflowInfo.getName().equals(name);
     }
 
-    public void checkExecFileAvailable(String user, ExecFileInfo execFileInfo) {
+    public void checkExecFileAvailable(String user, ExecFileInfo execFileInfo, String commitId) {
         if (execFileInfo == null) {
             throw new ByzerException(ErrorCodeEnum.WORKFLOW_NOT_EXIST);
         }
+        // user can access demo commits
+        if (Objects.nonNull(commitId) && !commitId.isEmpty() && isDemo(execFileInfo.getId(), commitId)) return;
+
         if (!user.equalsIgnoreCase(execFileInfo.getUser()) && !user.equalsIgnoreCase("admin")) {
             throw new ByzerException(ErrorCodeEnum.WORKFLOW_NOT_AVAILABLE);
         }
@@ -365,8 +415,13 @@ public class WorkflowService implements FileInterface {
     @Override
     @Transactional
     public void delete(Integer workflowId) {
+        if (isDemo(workflowId)) {
+            throw new ByzerException("Workflow has been shared with other users");
+        }
         workflowRepository.deleteById(workflowId);
+        workflowCommitRepository.deleteByWorkflow(workflowId);
         nodeInfoRepository.deleteByWorkflow(workflowId);
+        nodeCommitRepository.deleteByWorkflow(workflowId);
         modelInfoRepository.deleteByWorkflowId(workflowId);
     }
 
@@ -400,12 +455,11 @@ public class WorkflowService implements FileInterface {
     }
 
     @Transactional
-    public WorkflowInfo importWorkflow(WorkflowDTO workflowDTO, Integer folderId, String type) {
+    public WorkflowInfo importWorkflow(WorkflowDTO workflowDTO, Integer folderId, String type, String user) {
         // create notebook
-        String user = WebUtils.getCurrentLoginUser();
         long timestamp = System.currentTimeMillis();
         WorkflowInfo workflowInfo = new WorkflowInfo();
-        workflowInfo.setUser(WebUtils.getCurrentLoginUser());
+        workflowInfo.setUser(user);
 
         if (isWorkflowExist(user, workflowDTO.getName(), folderId)) {
             String time = new SimpleDateFormat("yyyyMMddHHmmss", Locale.getDefault(Locale.Category.FORMAT)).format(new Date());
@@ -451,6 +505,12 @@ public class WorkflowService implements FileInterface {
         return workflowRepository.save(workflowInfo);
     }
 
+    public WorkflowInfo importWorkflow(WorkflowDTO workflowDTO, Integer folderId, String type) {
+        // create notebook
+        String user = WebUtils.getCurrentLoginUser();
+        return importWorkflow(workflowDTO, folderId, type, user);
+    }
+
     public ExecFileInfo importWorkflow(WorkflowDTO workflowDTO, Integer folderId) {
         return importWorkflow(workflowDTO, folderId, null);
     }
@@ -459,14 +519,34 @@ public class WorkflowService implements FileInterface {
         return importWorkflow(workflowDTO, null, null);
     }
 
-    public ExecFileDTO getWorkflow(Integer execFileId, String user) {
+    public WorkflowDTO getWorkflow(Integer execFileId, String user) {
         WorkflowInfo workflowInfo = findById(execFileId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, null);
 
         List<NodeInfo> nodeInfos = findNodeByWorkflow(execFileId);
         Map<Integer, ConnectionInfo> map = getUserConnectionMap(user);
 
-        return WorkflowDTO.valueOf(workflowInfo, nodeInfos, map);
+        WorkflowDTO dto = WorkflowDTO.valueOf(workflowInfo, nodeInfos, map);
+        if (isDemo(execFileId)) dto.setIsDemo(true);
+        return dto;
+    }
+
+    public WorkflowDTO getWorkflow(Integer execFileId, String user, String commitId) {
+        if (Objects.isNull(commitId) || commitId.isEmpty()) {
+            return getWorkflow(execFileId, user);
+        }
+
+        WorkflowInfo workflowInfo = findById(execFileId);
+        checkExecFileAvailable(user, workflowInfo, commitId);
+
+
+        workflowInfo = workflowFromCommit(execFileId, commitId, workflowInfo);
+        List<NodeInfo> nodeInfos = nodesFromCommit(execFileId, commitId);
+        Map<Integer, ConnectionInfo> map = getUserConnectionMap(user);
+
+        WorkflowDTO dto = WorkflowDTO.valueOf(workflowInfo, nodeInfos, map);
+        if (isDemo(execFileId, commitId)) dto.setIsDemo(true);
+        return dto;
     }
 
     public Map<String, List<ParamDefDTO>> getAlgoParamSettings() {
@@ -511,17 +591,24 @@ public class WorkflowService implements FileInterface {
 
     }
 
-    public WorkflowContentDTO getWorkflowContent(String user, Integer workflowId) {
+    public WorkflowContentDTO getWorkflowContent(String user, Integer workflowId, String commitId) {
         WorkflowInfo workflowInfo = findById(workflowId);
-        checkExecFileAvailable(user, workflowInfo);
+        checkExecFileAvailable(user, workflowInfo, commitId);
         List<NodeInfo> nodeInfoList = findNodeByWorkflow(workflowId);
+
+        if (Objects.nonNull(commitId) && !commitId.isEmpty()) {
+            workflowInfo = workflowFromCommit(workflowId, commitId, workflowInfo);
+            nodeInfoList = nodesFromCommit(workflowId, commitId);
+        }
+
+
         Map<Integer, ConnectionInfo> connectionInfoMap = getUserConnectionMap(workflowInfo.getUser());
         Map<String, List<ParamDefDTO>> algoParams = getAlgoParamSettings();
         return WorkflowContentDTO.valueOf(workflowInfo, nodeInfoList, connectionInfoMap, algoParams);
     }
 
-    public String getWorkflowScripts(String user, Integer workflowId, Map<String, String> options) {
-        WorkflowContentDTO content = getWorkflowContent(user, workflowId);
+    public String getWorkflowScripts(String user, Integer workflowId, String commitId, Map<String, String> options) {
+        WorkflowContentDTO content = getWorkflowContent(user, workflowId, commitId);
         List<String> scripts = content.getCellList().stream().map(WorkflowContentDTO.WorkflowCellContent::getContent)
                 .filter(Objects::nonNull).map(sql -> HintManager.applyAllHintRewrite(sql, options))
                 .collect(Collectors.toList());
@@ -581,5 +668,57 @@ public class WorkflowService implements FileInterface {
             nodeContent.setTarget(nodeContent.getOutputParam().get(1).getValue());
             nodeContent.setSavePath(nodeContent.getOutputParam().get(0).getValue());
         }
+    }
+
+    private boolean isDemo(Integer workflowId) {
+        return !sharedFileRepository.findByEntity("admin", workflowId, "workflow").isEmpty();
+    }
+
+    private boolean isDemo(Integer workflowId, String commitId) {
+        return !sharedFileRepository.findByCommit("admin", workflowId, "workflow", commitId).isEmpty();
+    }
+
+    public WorkflowCommit findCommit(Integer workflowId, String commitId) {
+        List<WorkflowCommit> workflowCommits = workflowCommitRepository.findByCommit(workflowId, commitId);
+
+        if (workflowCommits.isEmpty()) {
+            throw new ByzerException("Commit don't exist");
+        }
+
+        return workflowCommits.get(0);
+    }
+
+    private WorkflowInfo workflowFromCommit(Integer workflowId, String commitId, WorkflowInfo currentInfo){
+        WorkflowCommit workflowCommit = findCommit(workflowId, commitId);
+
+        WorkflowInfo workflowInfo = new WorkflowInfo();
+        workflowInfo.setId(workflowCommit.getWorkflowId());
+        workflowInfo.setName(workflowCommit.getName());
+        workflowInfo.setCreateTime(workflowCommit.getCreateTime());
+        workflowInfo.setUpdateTime(workflowCommit.getCreateTime());
+        workflowInfo.setFolderId(currentInfo.getFolderId());
+        workflowInfo.setUser(currentInfo.getUser());
+
+        return workflowInfo;
+    }
+
+    private List<NodeInfo> nodesFromCommit(Integer workflowId, String commitId){
+        List<NodeCommit> committedNodeInfos = getCommittedNodeInfos(workflowId, commitId);
+        return committedNodeInfos.stream().map(
+                nodeCommit -> {
+                    NodeInfo nodeInfo = new NodeInfo();
+                    nodeInfo.setId(nodeCommit.getNodeId());
+                    nodeInfo.setWorkflowId(nodeCommit.getWorkflowId());
+                    nodeInfo.setInput(nodeCommit.getInput());
+                    nodeInfo.setOutput(nodeCommit.getOutput());
+                    nodeInfo.setUser(nodeCommit.getUser());
+                    nodeInfo.setContent(nodeCommit.getContent());
+                    nodeInfo.setPosition(nodeCommit.getPosition());
+                    nodeInfo.setType(nodeCommit.getType());
+                    nodeInfo.setCreateTime(nodeCommit.getCreateTime());
+                    nodeInfo.setUpdateTime(nodeCommit.getCreateTime());
+                    return nodeInfo;
+                }
+        ).collect(Collectors.toList());
     }
 }

--- a/src/main/java/io/kyligence/notebook/console/support/UsageTempEnum.java
+++ b/src/main/java/io/kyligence/notebook/console/support/UsageTempEnum.java
@@ -1,3 +1,0 @@
-package io.kyligence.notebook.console.support;
-
-

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -1,6 +1,9 @@
 <?xml version="1.1" encoding="UTF-8" standalone="no"?>
 
-<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
     <include file="db/changelog/v1.0.0_2021-08-18_01_init_notebook_db.sql"/>
     <include file="db/changelog/v1.0.0_2021-08-18_02_add_new_column_and_unique_index.sql"/>
     <include file="db/changelog/v1.0.0_2021-08-20_01_change_unique_index_for_connection_name.sql"/>
@@ -14,4 +17,5 @@
     <include file="db/changelog/v1.0.0_2021-11-12_01_add_et_param_coverage.sql"/>
     <include file="db/changelog/v1.0.0_2021-11-19_01_add_schedule_account.sql"/>
     <include file="db/changelog/v1.0.0_2021-12-08_01_update_admin_default_pw.sql"/>
+    <include file="db/changelog/v1.0.1_2022-01-13_01_support_for_version_control_and_demo_update.sql"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/v1.0.1_2022-01-13_01_support_for_version_control_and_demo_update.sql
+++ b/src/main/resources/db/changelog/v1.0.1_2022-01-13_01_support_for_version_control_and_demo_update.sql
@@ -1,0 +1,73 @@
+--liquibase formatted sql
+
+--changeset jinghua.zhan:15
+--labels: add table
+--tag: 1.0.1
+
+DROP TABLE IF EXISTS `cell_commit`;
+CREATE TABLE `cell_commit` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `cell_id` int(11) unsigned NOT NULL,
+  `notebook_id` int(11) unsigned NOT NULL,
+  `content` text,
+  `commit_id` varchar(64) NOT NULL,
+  `last_job_id` varchar(255) DEFAULT NULL,
+  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `idx_commit` (`notebook_id`,`commit_id`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `shared_file`;
+CREATE TABLE `shared_file` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `owner` varchar(255) DEFAULT NULL,
+  `entity_id` int(11) DEFAULT NULL,
+  `entity_type` varchar(15) DEFAULT NULL,
+  `commit_id` varchar(40) NOT NULL,
+  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  `update_time` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_entity` (`entity_id`,`entity_type`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=29 DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `node_commit`;
+CREATE TABLE `node_commit` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `node_id` int(11) unsigned NOT NULL,
+  `workflow_id` int(11) NOT NULL,
+  `content` text,
+  `commit_id` varchar(64) NOT NULL,
+  `user` varchar(255) NOT NULL,
+  `position` varchar(255) DEFAULT NULL,
+  `input` text,
+  `output` text,
+  `type` varchar(255) DEFAULT NULL,
+  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `idx_commit` (`workflow_id`,`commit_id`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `notebook_commit`;
+CREATE TABLE `notebook_commit` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `notebook_id` int(11) unsigned NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `commit_id` varchar(64) NOT NULL,
+  `cell_list` longtext,
+  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `idx_commit` (`notebook_id`,`commit_id`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=53 DEFAULT CHARSET=utf8mb4;
+
+DROP TABLE IF EXISTS `workflow_commit`;
+CREATE TABLE `workflow_commit` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `workflow_id` int(11) DEFAULT NULL,
+  `name` varchar(255) NOT NULL,
+  `commit_id` varchar(64) NOT NULL,
+  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`) USING BTREE,
+  KEY `idx_commit` (`workflow_id`,`commit_id`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4;
+
+--comment: add support for version control and demo update


### PR DESCRIPTION
## I. Version Control

Add version control for Notebook/workflow entities, allowing users to view previously saved versions. 

At this stage, this is mainly to solve the problem when the admin user needs to update the demo.

1. Add COMMIT TABLES `cell_commit, notebook_commit node_commit, workflow_commit` to record the version commit information of notebook/workflow entities.

```SQL
DROP TABLE IF EXISTS `cell_commit`;
CREATE TABLE `cell_commit` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `cell_id` int(11) unsigned NOT NULL,
  `notebook_id` int(11) unsigned NOT NULL,
  `content` text,
  `commit_id` varchar(64) NOT NULL,
  `last_job_id` varchar(255) DEFAULT NULL,
  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`) USING BTREE,
  KEY `idx_commit` (`notebook_id`,`commit_id`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;

DROP TABLE IF EXISTS `node_commit`;
CREATE TABLE `node_commit` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `node_id` int(11) unsigned NOT NULL,
  `workflow_id` int(11) NOT NULL,
  `content` text,
  `commit_id` varchar(64) NOT NULL,
  `user` varchar(255) NOT NULL,
  `position` varchar(255) DEFAULT NULL,
  `input` text,
  `output` text,
  `type` varchar(255) DEFAULT NULL,
  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`) USING BTREE,
  KEY `idx_commit` (`workflow_id`,`commit_id`) USING BTREE
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

DROP TABLE IF EXISTS `notebook_commit`;
CREATE TABLE `notebook_commit` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `notebook_id` int(11) unsigned NOT NULL,
  `name` varchar(255) NOT NULL,
  `commit_id` varchar(64) NOT NULL,
  `cell_list` longtext,
  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`) USING BTREE,
  KEY `idx_commit` (`notebook_id`,`commit_id`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=53 DEFAULT CHARSET=utf8mb4;

DROP TABLE IF EXISTS `workflow_commit`;
CREATE TABLE `workflow_commit` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `workflow_id` int(11) DEFAULT NULL,
  `name` varchar(255) NOT NULL,
  `commit_id` varchar(64) NOT NULL,
  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`) USING BTREE,
  KEY `idx_commit` (`workflow_id`,`commit_id`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4;
```

1. API changes

- Add `POST /API/{notebook | workflow}/{id}/commit ` save current version to commit tables and return commit_id.

When the API is called, the backend generates commit_id in real-time, copies the latest version of the current resource (notebook/workflow), and saves the version of this commit in notebook_commit (workflow_commit) and cell_commit (node_commit).

Entity contents of the committed version are read-only.

```Java
@ApiOperation("Add Demo")
@PostMapping("/api/notebook/{id}/commit")
@Permission
public Response<String> commit(Integer entityId, Integer entityType) {
    // 自动资源的版本commit
   String commit_id = NotebookService.commit(entityId, entityType);
   return commit_id
}
```

- Adjust the API  `GET /api/{notebook | workflow/{id}  `Add parameter `commit_id`  to get the resource version of the specified commit

```
GET /api/{notebook|workflow/{id}?commit_id={commit_id}
```

- Adjust the API `GET /api/file/clone ` add `commit_id` parameters, clone specify the resource version of the commit

## II. Demo publish

1. Add TABLE  `shared_file`  to record the demo set by the admin user, which contains the id and commits information of notebook/workflow. After the admin user sets the demo, the content of the notebook/workflow  from this commit is visible to all  users

```SQL
DROP TABLE IF EXISTS `shared_file`;
CREATE TABLE `shared_file` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `owner` varchar(255) DEFAULT NULL,
  `entity_id` int(11) DEFAULT NULL,
  `entity_type` varchar(15) DEFAULT NULL,
  `commit_id` varchar(40) NOT NULL,
  `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
  `update_time` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`id`),
  KEY `idx_entity` (`entity_id`,`entity_type`) USING BTREE
) ENGINE=InnoDB AUTO_INCREMENT=29 DEFAULT CHARSET=utf8mb4;
```

1.  `SettingsController ` provides set/delete demo interface

```
POST /api/settings/demo
```

Body: 

```JSON
{
 "entity_id": 1,
 "entity_type": "notebook" 
}

```

```
POST /api/settings/demo/remove
```

Body same with above

```java
@ApiOperation("Add Demo")
@PostMapping("/settings/demo")
@Permission
public Response<Integer> addDemo(Integer entityId, Integer entityType) {

    // 自动资源的版本commit
    String commit_id = NotebookService.commit(entityId, entityType);
    // 增加/更新 demo 入口
    Integer id = DemoService.add(entityId, entityType，commid_id);
    return id;
}

@ApiOperation("Remove Demo")
@PostMapping("/settings/demo/remove")
@Permission
public Response<String> removeDemo(Integer entityId, Integer entityType) {
    DemoService.deleteDemo(entityId, entityType);
    return "success"
}
```

1. Adjust API `GET /api/user/me`  add `is_admin` fields to identify admin users. At this stage, only admin users can set/delete the demo.
2. Add `FileShareService ` responsible for maintaining demo information and caching demo resources.

```java
public class FileShareService {
    private NotebookTreeDTO cachedDemo;
    public void addDemo(Integer entityId, Integer entityType){
    }

    public void deleteDemo(Integer entityId, Integer entityType){
    }

    public NotebookTreeDTO getDemo(){
        if Objects.isNull(cachedDemo){
            cachedDemo = loadDemo()
        }
        return cachedDemo;
    }

    private NotebookTreeDTO loadDemo(){
        // 读取 demo_info 记录中 的 notebook 和 workflow, 生成 NotebookTreeDTO
        return ...
    }

}
```

1. Adjust API `/api/files ` add demos to user's file, add `commit_id `fields to the demo record and set the `is_demo = true ` flag

```java
@Service
public class FolderService {
// ...
    @Autowired
    private DemoService demoService;

    public  NotebookTreeDTO getNotebookTree(String user) {
        List<NotebookInfo> notebooks = notebookService.find(user);
        List<WorkflowInfo> workflows = workflowService.find(user);
        List<NotebookFolder> folders = this.findFolders(user);
        List<ExecFileInfo> execFiles = ExecFileInfo.createArrayFiles(notebooks, workflows);

        NotebookTreeDTO userFiles = NotebookTreeDTO.valueOf(execFiles, folders);
        List<NotebookTreeDTO> newFiles = Arrays.asList(demoService.getDemo());
        newFiles.addAll(userFiles.getList());
        userFiles.setList(newFiles);
        return userFiles;
    }

}
```


>  中文说明：
> ## 一. 版本管理
> 
> Notebook/Workflow 增加版本管理功能，用户可查看之前保存的版本。
> 
> 现阶段引入主要是为解决管理员发布 demo 后，需要更新 demo 时做版本替换，更多的功能放在后续版本中迭代。 
> 
> 1. 新增cell_commit, notebook_commit node_commit, workflow_commit 表记录 notebook/workflow 的版本 commit 信息
> 
> ```SQL
> DROP TABLE IF EXISTS `cell_commit`;
> CREATE TABLE `cell_commit` (
>   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
>   `cell_id` int(11) unsigned NOT NULL,
>   `notebook_id` int(11) unsigned NOT NULL,
>   `content` text,
>   `commit_id` varchar(64) NOT NULL,
>   `last_job_id` varchar(255) DEFAULT NULL,
>   `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
>   PRIMARY KEY (`id`) USING BTREE,
>   KEY `idx_commit` (`notebook_id`,`commit_id`) USING BTREE
> ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
> 
> DROP TABLE IF EXISTS `node_commit`;
> CREATE TABLE `node_commit` (
>   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
>   `node_id` int(11) unsigned NOT NULL,
>   `workflow_id` int(11) NOT NULL,
>   `content` text,
>   `commit_id` varchar(64) NOT NULL,
>   `user` varchar(255) NOT NULL,
>   `position` varchar(255) DEFAULT NULL,
>   `input` text,
>   `output` text,
>   `type` varchar(255) DEFAULT NULL,
>   `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
>   PRIMARY KEY (`id`) USING BTREE,
>   KEY `idx_commit` (`workflow_id`,`commit_id`) USING BTREE
> ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
> 
> DROP TABLE IF EXISTS `notebook_commit`;
> CREATE TABLE `notebook_commit` (
>   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
>   `notebook_id` int(11) unsigned NOT NULL,
>   `name` varchar(255) NOT NULL,
>   `commit_id` varchar(64) NOT NULL,
>   `cell_list` longtext,
>   `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
>   PRIMARY KEY (`id`) USING BTREE,
>   KEY `idx_commit` (`notebook_id`,`commit_id`) USING BTREE
> ) ENGINE=InnoDB AUTO_INCREMENT=53 DEFAULT CHARSET=utf8mb4;
> 
> DROP TABLE IF EXISTS `workflow_commit`;
> CREATE TABLE `workflow_commit` (
>   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
>   `workflow_id` int(11) DEFAULT NULL,
>   `name` varchar(255) NOT NULL,
>   `commit_id` varchar(64) NOT NULL,
>   `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
>   PRIMARY KEY (`id`) USING BTREE,
>   KEY `idx_commit` (`workflow_id`,`commit_id`) USING BTREE
> ) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4;
> ```
> 
> 1. 接口变更
> 
> - 新增 `POST /api/{notebook|workflow}/{id}/commit`  生成 commit 保存当前版本并返回 commit_id。
> 
> 接口调用时，后端实时生成 commit_id，复制当前资源（notebook/workflow）最新版本内容，在 notebook_commit(workflow_commit)和 cell_commit(node_commit) 中保存此 commit 的版本内容。
> 
> commit的版本内容只读
> 
> ```Java
> @ApiOperation("Add Demo")
> 
> @PostMapping("/api/notebook/{id}/commit")
> 
> @Permission
> 
> public Response<String> commit(Integer entityId, Integer entityType) {
> 
>     // 自动资源的版本commit
> 
>     
> 
>    String commit_id = NotebookService.commit(entityId, entityType);
> 
>    return commit_id
> 
> }
> ```
> 
> - 调整接口 `GET /api/{notebook|workflow/{id}` 增加 commit_id 参数，获取指定 commit 的资源版本
> 
> ```
> GET /api/{notebook|workflow/{id}?commit_id={commit_id}
> ```
> 
> - 调整接口 `GET /api/file/clone` 增加 commit_id 参数，clone 指定 commit 的资源版本
> 
> ## 二. Demo 推送
> 
> 1. 新增 shared_file 表，记录管理员用户 admin 设置的 demo，其中包含 notebook/workflow 的 id 和 commit 信息。管理员用户设置demo后，对应版本的notebook/workflow对用户可见
> 
> ```SQL
> DROP TABLE IF EXISTS `shared_file`;
> CREATE TABLE `shared_file` (
>   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
>   `owner` varchar(255) DEFAULT NULL,
>   `entity_id` int(11) DEFAULT NULL,
>   `entity_type` varchar(15) DEFAULT NULL,
>   `commit_id` varchar(40) NOT NULL,
>   `create_time` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
>   `update_time` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
>   PRIMARY KEY (`id`),
>   KEY `idx_entity` (`entity_id`,`entity_type`) USING BTREE
> ) ENGINE=InnoDB AUTO_INCREMENT=29 DEFAULT CHARSET=utf8mb4;
> ```
> 
> 1.  `SettingsController` 提供设置/删除 demo 接口
> 
> ```
> POST /api/settings/demo
> ```
> 
> Body: 
> 
> ```JSON
> {
>  "entity_id": 1,
>  "entity_type": "notebook" 
> }
> 
> ```
> 
> ```
> POST /api/settings/demo/remove
> ```
> 
> Body 同上
> 
> ```java
> @ApiOperation("Add Demo")
> @PostMapping("/settings/demo")
> @Permission
> public Response<Integer> addDemo(Integer entityId, Integer entityType) {
> 
>     // 自动资源的版本commit
>     String commit_id = NotebookService.commit(entityId, entityType);
>     // 增加/更新 demo 入口
>     Integer id = DemoService.add(entityId, entityType，commid_id);
>     return id;
> }
> 
> 
> 
> @ApiOperation("Remove Demo")
> @PostMapping("/settings/demo/remove")
> @Permission
> public Response<String> removeDemo(Integer entityId, Integer entityType) {
>     DemoService.deleteDemo(entityId, entityType);
>     return "success"
> }
> ```
> 
> 1. 调整 `GET /api/user/me` 接口，在其中增加 is_admin 字段，标识 admin 用户，现阶段只有 admin 用户可设置/删除 demo 。
> 2. 新增 `FileShareService` 负责维护 demo 信息，缓存 demo 资源。
> 
> ```java
> public class FileShareService {
>     private NotebookTreeDTO cachedDemo;
> 
>     public void addDemo(Integer entityId, Integer entityType){
> 
>     }
> 
>     public void deleteDemo(Integer entityId, Integer entityType){
> 
>     }
> 
>     public NotebookTreeDTO getDemo(){
>         if Objects.isNull(cachedDemo){
>             cachedDemo = loadDemo()
>         }
>         return cachedDemo;
>     }
> 
>     private NotebookTreeDTO loadDemo(){
>         // 读取 demo_info 记录中 的 notebook 和 workflow, 生成 NotebookTreeDTO
>         return ...
>     }
> 
> }
> ```
> 
> 1. 调整 `/api/files` 接口，将 demo 添加至用户自有 file 之前，同时在 demo 记录中添加 `commit_id `字段并设置 `is_demo=true` 标记
> 
> ```java
> @Service
> 
> public class FolderService {
> // ...
>     @Autowired
>     private DemoService demoService;
> 
>     public  NotebookTreeDTO getNotebookTree(String user) {
>         List<NotebookInfo> notebooks = notebookService.find(user);
>         List<WorkflowInfo> workflows = workflowService.find(user);
>         List<NotebookFolder> folders = this.findFolders(user);
>         List<ExecFileInfo> execFiles = ExecFileInfo.createArrayFiles(notebooks, workflows);
> 
>         NotebookTreeDTO userFiles = NotebookTreeDTO.valueOf(execFiles, folders);
>         List<NotebookTreeDTO> newFiles = Arrays.asList(demoService.getDemo());
>         newFiles.addAll(userFiles.getList());
>         userFiles.setList(newFiles);
>         return userFiles;
>     }
> 
> }
> ```