### PR TITLE
fix hint: SQL maybe not changed.

### DIFF
--- a/src/main/scala/io/kyligence/notebook/console/scalalib/hint/HintManager.scala
+++ b/src/main/scala/io/kyligence/notebook/console/scalalib/hint/HintManager.scala
@@ -11,8 +11,11 @@ object HintManager {
     List(new DeployScriptHint, new DeployModelHint,new DeployPythonModelHint)
 
   def applyAllHintRewrite(sql: String, options: java.util.Map[String, String]): String = {
-    applyNoEffectRewrite(sql, options)
-    applyEffectRewrite(sql, options)
+    var tempSQL = applyNoEffectRewrite(sql, options)
+    if (tempSQL == sql) {
+      tempSQL = applyEffectRewrite(sql, options)
+    }
+    tempSQL
   }
 
   def applyNoEffectRewrite(sql: String, options: java.util.Map[String, String]): String = {


### PR DESCRIPTION
## BUG DESC
There is a bug before, python script will not run successfull.And, all hint cound not changed sql.

## ROOT CAUSE
In function `applyAllHintRewrite`, whther `applyNoEffectRewrite` already changed sql or not, applyEffectRewrite would always run.
That because loop stop when `tempSQL != sql`.

## DEV DESIGN
Add loop stop condition.