### PR TITLE
Increase server keepAliveTimeout to 100 minutes

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -96,6 +96,7 @@ server:
     max-threads: 200
     min-spare-threads: 10
     max-http-header-size: 1048576
+    keep-alive-timeout: 6000000
     accesslog:
       enabled: true
       directory: ${NOTEBOOK_HOME}/logs


### PR DESCRIPTION
## Changes in this PR
Under certain circumstances, byzer-lang (Engine) failed to send large amount of data by calling /api/job/callback. The error is "Connection reset". To fix this, increase keepAliveTimeout.

## Test result
Passed test on kyligence's internal environment.