### PR TITLE
add liveliness API and support user define probe sql for DataSource check

### DIFF
--- a/src/main/java/io/kyligence/notebook/console/bean/dto/ConnectionDTO.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/ConnectionDTO.java
@@ -2,7 +2,6 @@ package io.kyligence.notebook.console.bean.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kyligence.notebook.console.bean.entity.ConnectionInfo;
-import io.kyligence.notebook.console.support.EncryptUtils;
 import io.kyligence.notebook.console.util.JacksonUtils;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/io/kyligence/notebook/console/bean/dto/SystemStatus.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/SystemStatus.java
@@ -1,0 +1,14 @@
+package io.kyligence.notebook.console.bean.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class SystemStatus {
+    private String status;
+    private String msg;
+    private List<EngineStatusDTO> engineStatus;
+}

--- a/src/main/java/io/kyligence/notebook/console/service/SystemService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/SystemService.java
@@ -7,6 +7,7 @@ import io.kyligence.notebook.console.bean.entity.SystemConfig;
 import io.kyligence.notebook.console.dao.SystemConfigRepository;
 import io.kyligence.notebook.console.support.CriteriaQueryBuilder;
 import io.kyligence.notebook.console.support.EncryptUtils;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 
 
+@Slf4j
 @Service
 public class SystemService {
 
@@ -30,6 +32,17 @@ public class SystemService {
 
     @Resource
     private CriteriaQueryBuilder queryBuilder;
+
+    public boolean isMetaDBReachable() {
+        // test meta database reachable
+        try {
+            repository.findAll();
+            return true;
+        } catch (Exception ex) {
+            log.error("Can not access meta database table, please check database status!");
+            return false;
+        }
+    }
 
     @Transactional
     public void updateByUser(SystemConfig systemConfig) {

--- a/src/main/java/io/kyligence/notebook/console/util/ConnectionUtils.java
+++ b/src/main/java/io/kyligence/notebook/console/util/ConnectionUtils.java
@@ -2,10 +2,13 @@ package io.kyligence.notebook.console.util;
 
 import io.kyligence.notebook.console.bean.dto.ConnectionDTO;
 import io.kyligence.notebook.console.support.EncryptUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 public class ConnectionUtils {
+    public static final String PROBE_SQL_PARAM_NAME = "probeSQL";
 
     public static String renderSQL(String url, String driver, String user,
                                    String password, String name,
@@ -22,7 +25,9 @@ public class ConnectionUtils {
 
         if (parameter != null) {
             parameter.forEach(parameterMap -> {
-                if (parameterMap.getName() != null && !parameterMap.getName().isEmpty()){
+                if (StringUtils.isNotBlank(parameterMap.getName()) &&
+                        !parameterMap.getName().equalsIgnoreCase(PROBE_SQL_PARAM_NAME) &&
+                        StringUtils.isNotBlank(parameterMap.getValue())) {
                     builder.append(
                             String.format("and %1$s=\"%2$s\"\n", parameterMap.getName(), parameterMap.getValue())
                     );
@@ -44,5 +49,18 @@ public class ConnectionUtils {
                 connectionName,
                 content.getParameter()
         );
+    }
+
+    public static String parseProbeSql(List<ConnectionDTO.ParameterMap> userParameters) {
+        if (Objects.nonNull(userParameters)) {
+            for (ConnectionDTO.ParameterMap parameterMap : userParameters) {
+                if (StringUtils.isNotBlank(parameterMap.getName()) &&
+                        parameterMap.getName().equalsIgnoreCase(PROBE_SQL_PARAM_NAME) &&
+                        StringUtils.isNotBlank(parameterMap.getValue())) {
+                    return parameterMap.getValue();
+                }
+            }
+        }
+        return "select 1";
     }
 }

--- a/src/test/java/io/kyligence/notebook/console/service/ConnectionServiceTest.java
+++ b/src/test/java/io/kyligence/notebook/console/service/ConnectionServiceTest.java
@@ -57,7 +57,11 @@ public class ConnectionServiceTest extends NotebookLauncherBaseTest {
         ).respond(response().withBody(MOCK_CONNECTION_CONTENT));
         Assert.assertTrue(connectionService.testConnection(MOCK_CONNECTION, "default"));
         Assert.assertFalse(connectionService.testConnection(MOCK_CONNECTION, "backup"));
+        Assert.assertTrue(connectionService.testConnection(ConnectionDTO.valueOf(MOCK_CONNECTION)));
 
+        MOCK_CONNECTION.setParameter("[{\"name\":\"probeSQL\",\"value\": \"select 1 from testTB\"}]");
+        Assert.assertTrue(connectionService.testConnection(MOCK_CONNECTION, "default"));
+        Assert.assertFalse(connectionService.testConnection(MOCK_CONNECTION, "backup"));
         Assert.assertTrue(connectionService.testConnection(ConnectionDTO.valueOf(MOCK_CONNECTION)));
     }
 
@@ -70,10 +74,5 @@ public class ConnectionServiceTest extends NotebookLauncherBaseTest {
                 "and password=\"root\"\n" +
                 "as admin-mockConnectionForAdmin;";
         Assert.assertEquals(expectSQL, connectionService.renderConnectionSQL(MOCK_CONNECTION));
-    }
-
-    @Test
-    public void testCreateConnection() {
-
     }
 }

--- a/src/test/java/io/kyligence/notebook/console/service/SystemServiceTest.java
+++ b/src/test/java/io/kyligence/notebook/console/service/SystemServiceTest.java
@@ -4,11 +4,16 @@ import io.kyligence.notebook.console.NotebookConfig;
 import io.kyligence.notebook.console.NotebookLauncherBaseTest;
 import io.kyligence.notebook.console.bean.entity.SystemConfig;
 import io.kyligence.notebook.console.dao.SystemConfigRepository;
+import io.kyligence.notebook.console.exception.ByzerException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.PostConstruct;
+
+import static org.mockito.Mockito.when;
 
 public class SystemServiceTest extends NotebookLauncherBaseTest {
 
@@ -16,6 +21,12 @@ public class SystemServiceTest extends NotebookLauncherBaseTest {
 
     @Autowired
     private SystemService systemService;
+
+    @InjectMocks
+    private SystemService mockService;
+
+    @Mock
+    private SystemConfigRepository mockRepo;
 
     @Override
     @PostConstruct
@@ -37,5 +48,14 @@ public class SystemServiceTest extends NotebookLauncherBaseTest {
         systemService.updateByUser(config);
         config = systemService.getConfig("mockConfigUser2");
         Assert.assertEquals("backup", config.getEngine());
+    }
+
+    @Test
+    public void testMetaDBReachable () {
+        Assert.assertTrue(systemService.isMetaDBReachable());
+
+        when(mockRepo.findAll()).thenThrow(ByzerException.class);
+
+        Assert.assertFalse(mockService.isMetaDBReachable());
     }
 }


### PR DESCRIPTION
增加 2 个健康检测接口：

`GET /api/system/liveliness`  服务是否存活，非200状态标识服务已挂
`GET /api/system/readiness` 服务是否可用，非200状态标识不可用

支持用户在定义外部数据源试，指定 探针sql，在接口参数的 parameter 字段传入 `[{"name":"probeSQL", "value": "your sql"}....]` 即可 