### PR TITLE
dbType为Deltalake时过滤不需要的目录名称

### DIFF
--- a/src/main/java/io/kyligence/notebook/console/service/CatalogService.java
+++ b/src/main/java/io/kyligence/notebook/console/service/CatalogService.java
@@ -2,6 +2,7 @@ package io.kyligence.notebook.console.service;
 
 import io.kyligence.notebook.console.bean.model.FileInfo;
 import io.kyligence.notebook.console.util.JacksonUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -86,6 +87,7 @@ public class CatalogService {
             return null;
         }
         List<String> dbNames = dbWithTables.stream()
+                .filter(item -> !StringUtils.startsWithAny(item.get("database").toString(), ".","__"))
                 .map(item -> item.get("database").toString())
                 .distinct()
                 .collect(Collectors.toList());


### PR DESCRIPTION
<img width="303" alt="image" src="https://user-images.githubusercontent.com/8468837/176432088-612645de-4a55-4226-9c50-af86d166db8d.png">
需求：过滤掉不需要的目录名称

环境：引擎参数配置：streaming.datalake.path=/data/jfs，/data/jfs是一个juiceFS挂载的目录