### PR TITLE
Support decode sql which encryped by base64

### DIFF
--- a/src/main/java/io/kyligence/notebook/console/bean/dto/req/ScriptExecutionReq.java
+++ b/src/main/java/io/kyligence/notebook/console/bean/dto/req/ScriptExecutionReq.java
@@ -4,8 +4,10 @@ package io.kyligence.notebook.console.bean.dto.req;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.codec.binary.Base64;
 
 import javax.validation.constraints.NotBlank;
+import java.io.UnsupportedEncodingException;
 
 @Data
 @NoArgsConstructor
@@ -21,10 +23,24 @@ public class ScriptExecutionReq {
     @JsonProperty("cell_id")
     private Integer cellId;
 
+    @JsonProperty("encType")
+    private String encType;
+
     @JsonProperty("engine")
     private String engine;
 
     @JsonProperty("timeout")
     private Integer timeout;
+
+    public String getSql() {
+        if (encType != null && encType.equals("base64")) {
+            try {
+                return new String(Base64.decodeBase64(sql), "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                return sql;
+            }
+        }
+        return sql;
+    }
 
 }


### PR DESCRIPTION
When the Byzer script delivered from browser , it may trigger the interceptor of firewall in server. So we need to encode sql field in browser and then decode in notebook backend.

We add a new request flag `encType`, when encType is set and the value is `base64`, then the notebook backend will try to decode `sql ` field and then execute it.