### PR TITLE
[BUGFIX] Fix check port bug

### DIFF
--- a/build/check-1400-ports.sh
+++ b/build/check-1400-ports.sh
@@ -24,7 +24,7 @@ source $(cd -P -- "$(dirname -- "$0")" && pwd -P)/header.sh
 function checkRestPort() {
     echo "Checking rest port on ${MACHINE_OS}"
     if [[ $MACHINE_OS == "Linux" ]]; then
-        used=$(netstat -tpln | grep "$NOTEBOOK_PORT" | awk '{print $7}' | sed "s/\// /g")
+        used=$(netstat -tpln | grep -w "$NOTEBOOK_PORT" | awk '{print $7}' | sed "s/\// /g")
     elif [[ $MACHINE_OS == "Mac" ]]; then
         used=$(lsof -nP -iTCP:$NOTEBOOK_PORT -sTCP:LISTEN | grep $NOTEBOOK_PORT | awk '{print $2}')
     fi

--- a/build/check-1400-ports.sh
+++ b/build/check-1400-ports.sh
@@ -26,7 +26,7 @@ function checkRestPort() {
     if [[ $MACHINE_OS == "Linux" ]]; then
         used=$(netstat -tpln | grep -w "$NOTEBOOK_PORT" | awk '{print $7}' | sed "s/\// /g")
     elif [[ $MACHINE_OS == "Mac" ]]; then
-        used=$(lsof -nP -iTCP:$NOTEBOOK_PORT -sTCP:LISTEN | grep $NOTEBOOK_PORT | awk '{print $2}')
+        used=$(lsof -nP -iTCP:$NOTEBOOK_PORT -sTCP:LISTEN | grep -w $NOTEBOOK_PORT | awk '{print $2}')
     fi
     if [ ! -z "$used" ]; then
         quit "ERROR: Port ${NOTEBOOK_PORT} is in use, another Byzer Notebook is running?"


### PR DESCRIPTION
Original shell command "$(netstat -tpln | grep "$NOTEBOOK_PORT" will get a wrong result in some circumstances. For example, when a port like 19002 is used in the machine.
Use "grep -w" will fix it.